### PR TITLE
Add RCSF in import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,13 @@
 Package: TreeLS
 Type: Package
 Title: Terrestrial Point Cloud Processing of Forest Data
-Version: 2.0.2
-Date: 2020-08-21
+Version: 2.0.3
+Date: 2021-15-01
 Authors@R: c(person("Tiago", "de Conto", email = "tdc.florestal@gmail.com", role = c("aut", "cre")))
 Description: High performance algorithms for manipulation of terrestrial 'LiDAR' (but not only) point clouds for use in research and forest monitoring applications, being fully compatible with the 'LAS' infrastructure of 'lidR'. For in depth descriptions of stem denoising and segmentation algorithms refer to Conto et al. (2017) <doi:10.1016/j.compag.2017.10.019>.
 URL: https://github.com/tiagodc/TreeLS    
 Depends: R (>= 3.3.0), data.table (>= 1.12.0), magrittr (>= 1.5), lidR (>= 3.0.0)
-Imports: rgl, raster, sp, deldir, dismo, nabor, benchmarkme, rlas, glue, mathjaxr
+Imports: rgl, raster, sp, deldir, dismo, nabor, benchmarkme, rlas, RCSF, glue, mathjaxr
 License: GPL-3
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
I wanted to move RCSF from import to suggest in lidR but this created a reverse dependency fail. Consequently I put back RCSF in import in lidR. However I added RCSF in TreeLS so if you update TreeLS I will be able to move RCSF in suggest.

Cheers.